### PR TITLE
Add 'use strict' pragma, Add missing if clause for the score rating

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function processItem(element) {
   var titleAndYear;
 
   // if there is no rating titleAndYear is the whole string
-  if  {
+  if (rating.score < 0) {
     titleAndYear = titleData;
   } else {
     titleAndYear = titleData.substring(0, ratingStringPosition - 1);


### PR DESCRIPTION
Enforce strict mode operation.
Without the 'if' clause for the score rating, the module is unusable since an error is thrown.
Fixes #3 